### PR TITLE
Auto register provider, fix put and forever functions to return bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An example use is to have an array cache and Redis cache. Fetch items from the a
 composer require antriver/laravel-multi-cache
 ```
 
-Add this to your config/app.php `providers` array:
+The service provider will autoload, if you have disabled this add this to your config/app.php `providers` array:
 ```php
 Antriver\LaravelMultiCache\MultiStoreServiceProvider::class
 ```

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
         "phpunit/phpunit": "^10.5",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^8.19"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Antriver\\LaravelMultiCache\\MultiStoreServiceProvider"
+            ]
+        }
     }
 }

--- a/src/MultiStore.php
+++ b/src/MultiStore.php
@@ -127,9 +127,12 @@ class MultiStore implements Store
      */
     public function put($key, $value, $seconds)
     {
+        $success = true;
         foreach ($this->stores as $store) {
-            $store->put($key, $value, $seconds);
+            $success = $store->put($key, $value, $seconds) && $success;
         }
+
+        return $success;
     }
 
     /**
@@ -178,9 +181,12 @@ class MultiStore implements Store
      */
     public function forever($key, $value)
     {
+        $success = true;
         foreach ($this->stores as $store) {
-            $store->forever($key, $value);
+            $success = $store->forever($key, $value) && $success;
         }
+
+        return $success;
     }
 
     /**


### PR DESCRIPTION
You no longer need to manually register the provider in regular setups (tests for instance are excluded)
Fix: `Illuminate\Cache\Repository::set(): Return value must be of type bool, null returned`